### PR TITLE
Update currentTime value in Video.js cache

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -108,8 +108,10 @@ const offset = function(options) {
       }
 
       if (this._offsetStart !== undefined) {
-        return Player.__super__.currentTime
+        const t = Player.__super__.currentTime
           .apply(this) - this._offsetStart;
+        this.getCache().currentTime = t;
+        return t;
       }
       return Player.__super__.currentTime.apply(this);
     };


### PR DESCRIPTION
fixes #43 

The source of the problem is: SeekBar.getCurrentTime_() retrieves the current time from the cache when the player is in scrubbling mode (i.e. while the mouse button is down). The cached currentTime value is set at the end of Player.currentTime(). The videojs-offset plugin overrides Player.currentTime() and modifies the returned value, but the original (wrong) currentTime value gets cached. This patch fixes that by updating the cached value.

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
